### PR TITLE
[Failed] BOJ_숫자카드2

### DIFF
--- a/Week1/숫자카드2/suhyun.java
+++ b/Week1/숫자카드2/suhyun.java
@@ -1,0 +1,42 @@
+package Week1.숫자카드2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+/*
+자바, HashMap
+put(키, value)
+getOrDefault(키, 기본값)
+출력시, StringBuilder를 통해 시간단축가능
+ */
+public class suhyun {
+
+    static int n, m;
+    static StringTokenizer st;
+    static Map<Integer, Integer> nums = new HashMap<Integer, Integer>();
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine(), " ");
+        for(int i=0; i<n; i++){
+            int x = Integer.parseInt(st.nextToken());
+            nums.put(x, (nums.getOrDefault(x, 0) + 1));
+        }
+        m = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine(), " ");
+        StringBuilder sb = new StringBuilder();
+        for(int i=0; i<m; i++){
+            int x = Integer.parseInt(st.nextToken());
+            if (nums.containsKey(x)){
+                sb.append(nums.get(x) + " ");
+            } else {
+                sb.append(0 + " ");
+            }
+        }
+        System.out.println(sb);
+    }
+}

--- a/Week1/숫자카드2/suhyun.py
+++ b/Week1/숫자카드2/suhyun.py
@@ -1,0 +1,20 @@
+import sys
+si = sys.stdin.readline
+n = int(si())
+a = list(map(int, si().split()))
+dict = {}
+for x in a:
+    if x in dict:
+        dict[x] = dict[x] + 1
+    else:
+        dict[x] = 1
+
+print(dict)
+
+m = int(si())
+
+for x in list(map(int, si().split())):
+    if x in dict:
+        print(dict[x], end=' ')
+    else:
+        print(0, end=' ')


### PR DESCRIPTION
## 문제 및 풀이과정

[숫자카드2](https://www.acmicpc.net/problem/10816)

소요시간: 10분

- 처음엔 특정 원소를 찾기위해 순차탐색 혹은 이분탐색을 떠올렸다.
- 그러나, 특정 원소가 여러개인경우, 특정 원소를 발견했을때 mid의 조정을 왼쪽으로 해야할지, 오른쪽으로 해야할지 두가지의 경우가 생겨 이분탐색으로 풀 수 없음을 감지하였다.
- 단순히 입력을 받을 때, 파이썬으로는 딕셔너리, 자바로는 HashMap의 등장횟수를 value로 하여 저장하여, if x in dict: 혹은 containsKey를 이용해 특정 원소를 O(1)로 찾을 수 있는 방법이 있었다.

- 정리
- 따라서, **배열에 특정원소가 여러개이면서 특정 원소를 찾고 싶을때, 이분탐색 혹은 탐색이 아니라, Map/딕셔너리를 떠올리자!** 

---

## 궁금한 점