### PR TITLE
[Failed] PRG_연속된_부분수열의_합

### DIFF
--- a/Week1/연속된_부분수열의_합/yubin.py
+++ b/Week1/연속된_부분수열의_합/yubin.py
@@ -1,0 +1,52 @@
+# 스스로 구현
+def solution(sequence, k):
+    L = 0
+    R = len(sequence)-1
+    
+    LeftPlus = True
+    
+    while True:
+        sum_LR = sum(sequence[L:R+1])
+
+        if sum_LR==k:
+            # print('k')
+            return [L, R]
+        
+        if (L != R) & (sequence[L]==sequence[R]):
+            R = L + int(k / sequence[L]) - 1
+            # print('LR')
+            return [L, R]
+        
+        if sum_LR < k:
+            R -= 1
+            LeftPlus = False
+            if R < L:
+                L = R
+                
+        if LeftPlus:
+            L += 1
+        else:
+            L -= 1
+        # print(L, R)
+
+# 답안 참고 후 다시 푼 것
+def solution(sequence, k):
+    answer = [0, len(sequence)]
+    L, R = 0, 0
+    sum_LR = sequence[0]
+    
+    while True:
+        if sum_LR < k:
+            R += 1
+            if R == len(sequence):
+                break
+            sum_LR += sequence[R]
+        else:
+            if sum_LR == k:
+                if R-L < answer[1] - answer[0]:
+                    answer = [L, R]
+            sum_LR -= sequence[L]
+            L += 1
+    
+    return answer
+            


### PR DESCRIPTION
## 문제 및 풀이과정

[연속된 부분수열의 합](https://school.programmers.co.kr/learn/courses/30/lessons/178870)

소요시간: 35분 + 7분  

**[접근방식]**
- 처음엔 이중 for문 돌리는 방법을 생각 => 시간복잡도 때문에 기각
- 전체 합에서 큰 값 혹은 작은 값 빼는 방식 => 너무 단순한 방법. 둘을 함께 써야함.
- L, R 두 포인터 사용해서 `sequence[L:R+1]`의 합이 k면 [L, R] 리턴
    - L!=R & seq[L] == seq[R] => 모두 같은 수이므로 R=L+int(seq[L]/len(seq))-1과 동일. [L, R] 리턴
    - 합이 k보다 크면 L += 1
    - 합이 k보다 작으면 R-=1, L-=1

결과: 23.5/100  
시간초과, 런타임에러, 실패 골고루 분포한 걸 보니 아주 잘못된 방식으로 접근한 것으로 보임.

**[답안 참고]**
참고 코드: [link](https://velog.io/@sugyeonghh/%ED%94%84%EB%A1%9C%EA%B7%B8%EB%9E%98%EB%A8%B8%EC%8A%A4-%EC%97%B0%EC%86%8D%EB%90%9C-%EB%B6%80%EB%B6%84-%EC%88%98%EC%97%B4%EC%9D%98-%ED%95%A9Python)
- 투 포인터 방식을 사용한 것은 좋았으나, 각각을 끝과 끝에 두면 안 되는 것이었음. => 포인터 모두 한 쪽에서 시작
- sum 매번 seq에서 슬라이싱해서 돌리는 방식 시간초과 => 변수에 넣어두고 거기에 바로 더하거나 빼는 방식으로 사용
---