### PR TITLE
[Failed] PRG_뒤에 있는 큰 수 찾기(복습필요)

### DIFF
--- a/Week2/공통/가장가까운_같은글자/jiyoon.java
+++ b/Week2/공통/가장가까운_같은글자/jiyoon.java
@@ -1,0 +1,27 @@
+package Week2.공통.가장가까운_같은글자;
+
+class jiyoon {
+  public int[] solution(String s) {
+    boolean[] alphabet = new boolean[26];       // 첫 등장 확인용
+    int[] answer = new int[s.length()];
+
+    for (int i = 0; i < s.length(); i++) {
+      char c = s.charAt(i);
+      int n = c - 'a';
+
+      if (!alphabet[n]) {     // 첫 등장 이라면
+        answer[i] = -1;
+        alphabet[n] = true;
+      } else {                // 첫 등장이 아니라면
+        for (int j = 0; j < i ; j++) {
+          if (c == s.charAt(j)) {
+            answer[i] = i - j;
+          }
+
+        }
+      }
+
+    }
+    return answer;
+  }
+}

--- a/Week3/공통/뒤에있는큰수찾기/suhyun.py
+++ b/Week3/공통/뒤에있는큰수찾기/suhyun.py
@@ -1,0 +1,20 @@
+# numbers 길이가 1,000,000(백만) 
+# 순차탐색을 진행하면 백만*백만으로 1초안에 풀 수 없을 듯하다.
+# 따라서, 이분탐색으로 진행하자.
+# ans = numbers후, ans만 정렬해주었는데도 내부적으로 ans와 numbers가 정렬되어있다.
+# ans만 정렬시키도록 하기 위해 파이썬에서는 깊은 복사를 제공한다.
+# import copy, a = copy.deepcopy(복사하고자 하는 배열)
+# 9:20 ~ 9:40 오잉? 이 문제 어케 푸는거임? -> 이분탐색으로 접근하려고했다가 접근실패를 직감함.
+# 결국 답을 확인하였다.
+def solution(numbers):
+    n = len(numbers)
+    answer = [-1] * n
+    stack = [0] # 스택 초기화
+    
+    for i in range(1, n):
+        while stack and numbers[stack[-1]] < numbers[i]:
+            answer[stack.pop()] = numbers[i]
+        stack.append(i)
+    return answer
+
+print(solution([9, 1, 5, 3, 6, 2]))


### PR DESCRIPTION
## 문제 및 풀이과정

[뒤에 있는 큰 수 찾기](https://school.programmers.co.kr/learn/courses/30/lessons/154539?language=python3)

소요시간: 25분

numbers 길이가 1,000,000(백만) 
순차탐색을 진행하면 백만*백만으로 1초안에 풀 수 없을 듯하다.
따라서, 이분탐색으로 진행하자.
ans = numbers후, ans만 정렬해주었는데도 내부적으로 ans와 numbers가 정렬되어있다.
ans만 정렬시키도록 하기 위해 파이썬에서는 깊은 복사를 제공한다.
import copy, a = copy.deepcopy(복사하고자 하는 배열)
9:20 ~ 9:40 오잉? 이 문제 어케 푸는거임? -> 이분탐색으로 접근하려고했다가 접근실패를 직감함.
결국 답을 확인하였다.

## 참고자료

## 헷갈린 문법
      
## 궁금한 점

---