### PR TITLE
[Solved]PRG_실패율, 체육복, 모의고사 

### DIFF
--- a/Week6/공통/모의고사/yubin.py
+++ b/Week6/공통/모의고사/yubin.py
@@ -1,0 +1,22 @@
+from itertools import cycle
+def solution(answers):
+    answer = []
+    supo1 = cycle([1,2,3,4,5])
+    supo2 = cycle([2,1,2,3,2,4,2,5])
+    supo3 = cycle([3,3,1,1,2,2,4,4,5,5])
+    
+    score = [0, 0, 0]
+    for ans, s1, s2, s3 in zip(answers, supo1, supo2, supo3):
+        if s1==ans:
+            score[0] += 1
+        if s2==ans:
+            score[1] += 1
+        if s3==ans:
+            score[2] += 1
+    
+    max_score = max(score)
+
+    for idx, supo in enumerate(score):
+        if supo==max_score:
+            answer.append(idx+1)
+    return answer

--- a/Week6/공통/실패율/yubin.py
+++ b/Week6/공통/실패율/yubin.py
@@ -1,0 +1,23 @@
+from collections import defaultdict
+def solution(N, stages):
+    answer = []
+    total_user = len(stages)
+    
+    # 스테이지 별 멈춘 유저 수 저장
+    stage_user = defaultdict(int)
+    for s in stages:
+        stage_user[s] += 1
+    
+    fail_dict = defaultdict(int)
+    for stage in range(1, N+1):
+        if total_user == 0:
+            fail_dict[stage] = 0
+        else:
+            fail_dict[stage] = stage_user[stage]/total_user
+            total_user -= stage_user[stage]
+    
+    # print(fail_dict)
+    fail = dict(sorted(fail_dict.items(), key=lambda x: x[1], reverse=True))
+    # print(fail.keys())
+    
+    return list(fail.keys())

--- a/Week6/공통/체육복/yubin.py
+++ b/Week6/공통/체육복/yubin.py
@@ -1,0 +1,24 @@
+def solution(n, lost, reserve):
+    answer = 0
+    set_lost = set(lost)
+    set_reserve = set(reserve)
+    for student in range(1, n+1):
+        # 잃어버린 학생인지
+        if student in set_lost:
+            # 여분 있는지
+            if student in set_reserve:
+                set_reserve.remove(student)
+                answer +=1
+            # 여분 없어서 빌려야함
+            else:
+                if student-1 in set_reserve:
+                    set_reserve.remove(student-1)
+                    answer += 1
+                elif (student+1 in set_reserve) and (student+1 not in set_lost):
+                    set_reserve.remove(student+1)
+                    answer += 1
+        # 안 잃어버림
+        else:
+            answer +=1
+            
+    return answer


### PR DESCRIPTION
## 문제 및 풀이과정

[실패율](https://school.programmers.co.kr/learn/courses/30/lessons/42889)

소요시간: 15분
- total_user: 도전 사용자 인원
- stage_user: 스테이지 별 멈춘 유저 수 딕셔너리
- fail_dict: 스테이지 별 실패 확률 딕셔너리
    - value: stage_user[stage]/도전 사용자 인원
    - 도전 사용자 인원은 스테이지 지날 때마다 빼주기 ex. 1번 스테이지 도전 사용자 인원=8, 1번에서 멈춘 인원 1 => 2번 스테이지 도전 사용자 인원=7
- value 기준으로 내림차순 정렬한 후, 딕셔너리 키만 리스트로 반환
---
[체육복](https://school.programmers.co.kr/learn/courses/30/lessons/42862)

소요시간: 20분
- 학생 인원 30명 이하이므로 그냥 for문 다 돌리기
- 잃어버린 학생이라면 여분 있는지, 빌려야하는지 체크
- 안 잃어버린 학생이면 answer += 1
- set 사용하면 in 시간 복잡도 O(1)
---
[모의고사](https://school.programmers.co.kr/learn/courses/30/lessons/42840)

소요시간: 10분
- 수포자들은 정해진 패턴을 반복해서 찍으므로 cycle로 패턴 돌리게 만들기
- zip으로 answers, 수포자들 패턴 묶어서 돌리기 (가장 길이가 짧은 배열에 맞춰서 끝나게 됨)
- score에 정답 개수 누적
- 최대점수와 동일한 점수 가진 수포자들 answer에 추가
---

