### PR TITLE
[Failed] PRG_연속 부분 수열 합의 개수(복습필요), PRG_택배상자(복습필요)

### DIFF
--- a/Week5/공통/연속부분수열_합의개수/suhyun.py
+++ b/Week5/공통/연속부분수열_합의개수/suhyun.py
@@ -1,0 +1,14 @@
+from collections import deque
+def solution(elements):
+    answer = set()
+    elements = deque(elements)
+    for j in range(len(elements)):
+        k = elements.popleft()
+        elements.append(k)
+        for i in range(1,len(elements)):
+            print(list(elements)[:i])
+            answer.add(sum(list(elements)[:i]))
+    answer.add(sum(elements))
+    return len(answer)
+
+print(solution([7,9,1,1,4]))

--- a/Week5/공통/연속부분수열_합의개수/test.java
+++ b/Week5/공통/연속부분수열_합의개수/test.java
@@ -1,4 +1,0 @@
-package Week5.공통.연속부분수열_합의개수;
-
-public class test {
-}

--- a/Week5/공통/택배상자/suhyun.py
+++ b/Week5/공통/택배상자/suhyun.py
@@ -1,0 +1,17 @@
+from collections import deque
+def solution(order):
+    order = deque(order)
+    stack = []
+    result = [] #트럭에 실은 상자
+    for i in range(1, len(order) + 1):
+        stack.append(i)
+        while stack:
+            if stack and stack[-1] == order[0]:
+                num = order.popleft()
+                stack.pop()
+                result.append(num)
+            else:
+                break
+    return len(result)
+
+print(solution([4, 3, 1, 2, 5]))

--- a/Week5/공통/택배상자/test.java
+++ b/Week5/공통/택배상자/test.java
@@ -1,4 +1,0 @@
-package Week5.공통.택배상자;
-
-public class test {
-}


### PR DESCRIPTION
## 문제 및 풀이과정

[연속 부분 수열 합의 개수](https://school.programmers.co.kr/learn/courses/30/lessons/131701)

소요시간: 40분

- 문제에서는 길이가 1인 연속부분수열, 길이가 2인 연속부분수열 .. 길이가 n인 연속부분수열 이라고 나와있다.

- 접근을 달리하자.
- 요소를 하나씩 확인하며, 그 요소로부터 길이가 1, 길이가 2, 길이가 n-1인 연속부분수열을 만들어서 각각의 합을 구한뒤,
- 집합 answer에 추가한다.
- 마지막으로 길이가 n인 연속부분수열의 합을 구하기 위해 sum(리스트)를 구한후 answer에 추가한다.

## 참고자료

## 헷갈린 문법
      
## 궁금한 점

---
## 문제 및 풀이과정

[택배상자](https://school.programmers.co.kr/learn/courses/30/lessons/131704)

소요시간: 60분

- 열심히 구현했으나, 반례에서 걸려서 결국 답을 확인하였다.
- order를 deque로 만든다.
- 일단 서브컨테이너에 요소를 추가한후, 바로 서브컨테이너에 있는 마지막 원소와 order의 첫번째 원소를 비교한다.
- 만약 다르다면, while문을 빠져나오도록 한다.
- 만약 같다면, 서브컨테이너에 요소가 존재할때까지 서브컨테이너의 마지막원소와 order의 첫번째 원소를 비교하면서 
- 서브컨테이너의 마지막원소를 제거하는 방식으로 접근한다. (order도 마찬가지)

## 참고자료
- https://zmfpdl64.tistory.com/14

## 헷갈린 문법
      
## 궁금한 점

---